### PR TITLE
gh_commit: Add get command **WIP**

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Python, you should probably look into project like [github3py](http://github3py.
       * [release command](#release-command)
       * [asset command](#asset-command)
       * [ref command](#ref-command)
+      * [commit command](#commit-command)
    * [using the module](#using-the-module)
    * [testing](#testing)
    * [maintainers: how to make a release ?](#maintainers-how-to-make-a-release-)
@@ -269,6 +270,21 @@ It understands the following commands:
 | create    | ref sha                                | create reference (e.g heads/foo, tags/foo) |
 | list      | [--tags] [--pattern PATTERN]           | list all references                        |
 | delete    | pattern [--tags] [--keep-pattern KEEP_PATTERN] | delete selected references                 |
+
+
+## ``commit`` command
+
+This command deals with git commits. The general usage is:
+
+```bash
+githubrelease commit username/reponame command [options]
+```
+
+It understands the following commands:
+
+| command   | parameters                             | description                                |
+|-----------|----------------------------------------|--------------------------------------------|
+| get       | sha                                    | get commit properties                      |
 
 
 # using the module

--- a/github_release.py
+++ b/github_release.py
@@ -217,6 +217,17 @@ def gh_ref(ctx, repo_name):
     ctx.obj = repo_name
 
 
+@main.group("commit")
+@click.argument('repo_name', metavar="REPOSITORY")
+@click.pass_context
+@handle_http_error
+def gh_commit(ctx, repo_name):
+    """Manage commits (get) for
+    REPOSITORY (e.g jcfr/sandbox)
+    """
+    ctx.obj = repo_name
+
+
 #
 # Releases
 #
@@ -1028,6 +1039,18 @@ def gh_ref_delete(repo_name, pattern, keep_pattern=None, tags=False,
 #
 # Commits
 #
+
+@gh_commit.command("get")
+@click.argument("sha")
+@click.pass_obj
+def _cli_commit_get(*args, **kwargs):
+    """Get commit properties"""
+    commit = gh_commit_get(*args, **kwargs)
+    if commit is None:
+        print('could not find commit {0}'.format(kwargs['sha']))
+        return
+    print(commit)
+
 
 def gh_commit_get(repo_name, sha):
     try:


### PR DESCRIPTION
Todo:

* By default list all properties as:

   githubrelease commit REPO_NAME get SHA

   could output:

   sha 7921bb62e3b3240226acf66a57535219b9c3abac
   url https://api.github.com/repos/NeurodataWithoutBorders/pynwb/git/commits/7921bb62e3b3240226acf66a57535219b9c3abac
   html_url https://github.com/NeurodataWithoutBorders/pynwb/commit/7921bb62e3b3240226acf66a57535219b9c3abac
   author.name John Doe
   [...]


* support getting a single property using

  githubrelease commit REPO_NAME get SHA author.name

* support getting json output using

  githubrelease commit REPO_NAME get SHA --json




[ci skip]