### PR TITLE
Delete enhancement

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,16 @@ It understands the following commands:
   --verbose
 ```
 
+* delete:
+
+```bash
+  --keep-pattern KEEP_PATTERN
+  --type [all, draft, prerelease, release]
+  --older-than HOURS
+  --dry-run
+  --verbose
+```
+
 
 ## ``asset`` command
 

--- a/github_release.py
+++ b/github_release.py
@@ -552,9 +552,8 @@ def gh_release_delete(repo_name, pattern, keep_pattern=None, type='all',
                 print('skipping release {0}: type {1} is not {2}'.format(
                     release['tag_name'], get_release_type(release), type))
             continue
-        candidates.append(release['tag_name'])
-    for tag_name in candidates:
-        release = get_release(repo_name, tag_name)
+        candidates.append(release)
+    for release in candidates:
         print('deleting release {0}'.format(release['tag_name']))
         if dry_run:
             continue

--- a/github_release.py
+++ b/github_release.py
@@ -29,6 +29,8 @@ REQ_BUFFER_SIZE = 65536  # Chunk size when iterating a download body
 _github_token_cli_arg = None
 
 ZERO = timedelta(0)
+
+
 class UTC(tzinfo):
     """UTC"""
 
@@ -40,6 +42,8 @@ class UTC(tzinfo):
 
     def dst(self, dt):
         return ZERO
+
+
 utc = UTC()
 
 
@@ -571,7 +575,7 @@ def gh_release_delete(repo_name, pattern, keep_pattern=None, type='all', older_t
         # Assumes Zulu time.
         # See https://stackoverflow.com/questions/127803/how-to-parse-an-iso-8601-formatted-date
         rel_date = datetime.strptime(release['created_at'], "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=utc)
-        rel_age = int((datetime.now(utc) - rel_date).total_seconds() / 60 / 60) # In hours
+        rel_age = int((datetime.now(utc) - rel_date).total_seconds() / 60 / 60)  # In hours
         if older_than > rel_age:
             if verbose:
                 print('skipping release {0}: created less than {1} hours ago ({2}hrs)'.format(


### PR DESCRIPTION
Fixes #50 

You can now delete releases based on type (all, draft, prerelease or release) and on age (`-older-than HOURS`)

Also updates the docu (was missing verbose and dry-run) and fixes a performance bug: Releases were loaded in delete and again before deleting a single release causing a unnecessary slow down