### PR TITLE
patch_release: Explicitly check if body exceed maximum size

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,7 +25,7 @@ Python API
 Features (CLI and Python API)
 -----------------------------
 
-* ``delete`` command:
+* ``release`` command:
 
   * `delete`:
 
@@ -44,6 +44,10 @@ Issues (CLI and Python API)
   * ``delete`` command:
 
     * Speed-up release deletion. See [PR#51](https://github.com/j0057/github-release/pull/51). Contributed by [@Flamefire](https://github.com/Flamefire)
+
+  * ``edit`` command:
+
+    * Explicitly check if body exceed maximum size.
 
 Issues (Python API)
 -------------------

--- a/github_release.py
+++ b/github_release.py
@@ -427,6 +427,10 @@ def patch_release(repo_name, current_tag_name, **values):
             current_tag_name, "\n  ".join(updated)))
         print("")
 
+    if len(values.get("body", "")) >= 125000:
+        raise Exception('Failed to update release {0}. Description has {1} characters and maximum is 125000 characters'.format(
+          release["tag_name"], len(values["body"])))
+
     data.update(values)
 
     if not dry_run:


### PR DESCRIPTION
This will avoid to the following error:

```
  422 Client Error: Unprocessable Entity for url
```

associated with these details:

```json
  {
    "message": "Validation Failed",
    "errors": [
      {
        "resource": "Release",
        "code": "custom",
        "field": "body",
        "message": "body is too long (maximum is 125000 characters)"
      }
    ],
    "documentation_url": "https://docs.github.com/rest/reference/repos#update-a-release"
  }
```