### PR TITLE
Fix click 8 incompatibility

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,6 +35,8 @@ Features (CLI and Python API)
 Issues (CLI and Python API)
 ---------------------------
 
+* Fix click 8 support using ``ProgressBar.length is not None`` instead of the obsolete ``ProgressBar.length_known``. Contributed by [@rly](https://github.com/rly)
+
 * ``release`` command:
 
   * ``release-notes``:

--- a/github_release.py
+++ b/github_release.py
@@ -154,7 +154,7 @@ def _progress_bar(*args, **kwargs):
 
     def formatPos(_self):
         pos = formatSize(_self.pos)
-        if _self.length_known:
+        if _self.length is not None:
             pos += '/%s' % formatSize(_self.length)
         return pos
 


### PR DESCRIPTION
Fix #62.

According to the changelog in `src/click/_termui_impl.py` in https://github.com/pallets/click/pull/1856/files, `ProgressBar.length_known` was replaced by `ProgressBar.length is not None`